### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Review it, and write your own protocol.
   
 ## 安装
 
-`DRDNetworking` 使用`Cocoapods`来进行集成 [CocoaPods](http://cocoapods.org).   
+`DRDNetworking` 使用`CocoaPods`来进行集成 [CocoaPods](http://cocoapods.org).   
 在您的`Podfile`里添加以下代码即可集成`DRDNetworking`:  
   
 ```


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
