### PR TITLE
fix bug for completion Group in same request cancel error

### DIFF
--- a/Pod/Classes/DRDAPIManager.m
+++ b/Pod/Classes/DRDAPIManager.m
@@ -342,9 +342,11 @@ static DRDAPIManager *sharedDRDAPIManager       = nil;
                                                    code:NSURLErrorCancelled
                                                userInfo:userInfo];
         [self callAPICompletion:api obj:nil error:cancelError];
+        if (completionGroup) {
+            dispatch_group_leave(completionGroup);
+        }
         return;
     }
-
     
     void (^successBlock)(NSURLSessionDataTask *task, id responseObject)
     = ^(NSURLSessionDataTask * task, id responseObject) {


### PR DESCRIPTION
Bug fix for completion Group in 
- (void)_sendSingleAPIRequest:(DRDBaseAPI *)api
         withSessionManager:(AFHTTPSessionManager *)sessionManager
         andCompletionGroup:(dispatch_group_t)completionGroup;

Thanks for "RomeoLeft" in JianShu Pointing out this bug.
