### PR TITLE
增加batch的block回调

### DIFF
--- a/Pod/Classes/DRDAPIBatchAPIRequests.h
+++ b/Pod/Classes/DRDAPIBatchAPIRequests.h
@@ -35,6 +35,12 @@
 @property (nonatomic, weak, nullable) id<DRDAPIBatchAPIRequestsProtocol> delegate;
 
 /**
+ *  Batch 完成后的执行体
+ *  batchApis batchApis
+ */
+@property (nonatomic, copy, nullable) void (^apiCompletionHandler)(DRDAPIBatchAPIRequests * _Nullable batchApis);
+
+/**
  *  将API 加入到BatchRequest Set 集合中
  *
  *  @param api

--- a/Pod/Classes/DRDAPIManager.m
+++ b/Pod/Classes/DRDAPIManager.m
@@ -311,6 +311,9 @@ static DRDAPIManager *sharedDRDAPIManager       = nil;
         if (apis.delegate) {
             [apis.delegate batchAPIRequestsDidFinished:apis];
         }
+        if ([apis apiCompletionHandler]) {
+            apis.apiCompletionHandler(apis);
+       }
     });
 }
 

--- a/Pod/Classes/DRDBaseAPI.m
+++ b/Pod/Classes/DRDBaseAPI.m
@@ -76,6 +76,7 @@
     return [NSSet setWithObjects:
             @"text/json",
             @"text/html",
+            @"text/plain",
             @"application/json",
             @"text/javascript", nil];
 }


### PR DESCRIPTION
如题，最近和两个同事碰到多个请求，在同一个方法里等待回调返回值的需求，使用delegate不能直接在同一个方法里return结果。

最后是自己拿gcd解决的。希望DRDNetworking给batch增加此方法。
